### PR TITLE
Timestamp format

### DIFF
--- a/.prettylog.yml
+++ b/.prettylog.yml
@@ -2,6 +2,7 @@ timestamp:
   key: time
   visible: true
   colors: [32,12,34]
+  format: "02/01/2006 15:04:05"
 
 logger:
   key: logger

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pasta onde a ferramenta é executada), quando globalmente (na pasta `$HOME`). A 
       key:     <string>
       visible: <bool> 
       color:   <list of int>
+      format:  <string>
 
     logger:
       key:     <string>
@@ -78,6 +79,8 @@ Cada chave configura a formatação de um campo do log, e o significado de cada 
 - **padding**: Quantidade de espaços em branco a serem adicionados à direita do texto do campo.
 - **color/colors**: Atributos de cor usados para colorir o texto do campo. Até 3 valores podem ser informados 
 (foreground, background e effects), de acordo com a [tabela para cores ASCII](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
+- **format**: Atributo exclusivo para Timestamp que define o formato da data a ser exibido na tela. O valor desse atributo
+deve seguir as [especificações da linguagem Go](https://golang.org/pkg/time/#pkg-constants) para formato de datas.
 
 ## Utilização com outras ferramentas de linha de comando
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ func init() {
 	viper.SetConfigType("yaml")
 	viper.SetConfigName(".prettylog")
 	viper.AddConfigPath(".")
+	viper.AddConfigPath("./..")
 	viper.AddConfigPath("$HOME/")
 }
 

--- a/prettifiers/default.go
+++ b/prettifiers/default.go
@@ -2,8 +2,8 @@ package prettifiers
 
 import (
 	"bytes"
-
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/globocom/prettylog/config"
@@ -22,7 +22,12 @@ func (p *DefaultPrettifier) Prettify(line *parsers.ParsedLine) string {
 	buffer := &bytes.Buffer{}
 
 	if settings.Timestamp.Visible {
-		writeTo(buffer, line.Timestamp, 0, settings.Timestamp.Color)
+		ts, err := time.Parse(time.RFC3339, line.Timestamp)
+		if err != nil || settings.Timestamp.Format == "" {
+			writeTo(buffer, line.Timestamp, 0, settings.Timestamp.Color)
+		} else {
+			writeTo(buffer, ts.Format(settings.Timestamp.Format), 0, settings.Timestamp.Color)
+		}
 	}
 
 	if settings.Logger.Visible && line.Logger != "" {


### PR DESCRIPTION
This PR solves issue #3.
Main idea of the changes are:
* If timestamp can be parsed to a Golang `*time.Time`, then it formats with the format from the config file
* If timestamp can't be parsed or if there is no format in the config file, then it prints timestamp as is.