### PR TITLE
Translating README from Portuguese to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GoDoc](https://godoc.org/github.com/globocom/prettylog?status.svg)](https://godoc.org/github.com/globocom/prettylog)
 [![Go Report Card](https://goreportcard.com/badge/github.com/globocom/prettylog)](https://goreportcard.com/report/github.com/globocom/prettylog)
 
-Application to display structured JSON logs in a format compatible with human beings.
+Application to display JSON logs structured in a format understandable by humans.
 
 ![Prettylog](https://github.com/globocom/prettylog/raw/master/prettylog.png)
 

--- a/README.md
+++ b/README.md
@@ -3,43 +3,40 @@
 [![GoDoc](https://godoc.org/github.com/globocom/prettylog?status.svg)](https://godoc.org/github.com/globocom/prettylog)
 [![Go Report Card](https://goreportcard.com/badge/github.com/globocom/prettylog)](https://goreportcard.com/report/github.com/globocom/prettylog)
 
-Ferramenta para exibição de logs estruturados em JSON em formato compatível com seres humanos.
+Application to display structured JSON logs in a format compatible with human beings.
 
 ![Prettylog](https://github.com/globocom/prettylog/raw/master/prettylog.png)
 
-## Instalação
+## Installation
 
     curl https://github.com/globocom/prettylog/raw/master/install.sh | sh 
 
-Assumindo que a pasta `$GOPATH/bin` esteja adicionada ao `PATH` do usuário atual, a aplicação ficará disponível para 
-utilização imediatamente após a instalação.
+Assuming that the `$GOPATH/bin` folder is added to the `PATH` of the current user, the application will be available for use immediately after installation.
 
-## Funcionamento
 
-Prettylog processa logs contendo um número arbitrário de campos, e produz uma saída amigável no seguinte formato:
+## Running
+
+Prettylog processes logs containing an arbitrary number of fields, and produces friendly output in the following format:
 
     <TIMESTAMP> <LOGGER> <CALLER> <LEVEL> <MESSAGE> <FIELD1>=<VALUE> <FIELD2>=<VALUE> ...
 
-Se um determinado campo não existir no log, ele será ignorado na saída gerada.
+If a given field does not exist in the log, it will be ignored in the output generated.
 
-**NOTA**: Atualmente apenas logs no formato JSON são suportados. Logs em outros formatos, ou sem formato algum, serão
-impressos sem nenhuma modificação.
+**NOTE**: Currently only logs in JSON format are supported. Logs in other formats, or without any format, will be printed without any modification.
 
-## Utilização
+## Usage
 
-A ferramenta foi projetada para ler diretamente o `stdout` de uma aplicação que produza logs em formato estruturado:
+The tool was designed to directly read the `stdout` of an application that produces logs in a structured format:
 
     app | prettylog
 
-Se a aplicação escrever logs no `stderr` ao invés do `stdout`, um redirecionamento é necessário para a ferramenta 
-funcionar corretamente:
+If the application writes logs to `stderr` instead of `stdout`, a redirect is required for the tool function properly:
 
     app 2>&1 | prettylog
 
-## Configuração
+## Configuration
 
-A ferramenta pode ser configurada através do arquivo `.prettylog.yml`, que pode estar localizado tanto localmente (na
-pasta onde a ferramenta é executada), quando globalmente (na pasta `$HOME`). A estrutura do arquivo é a seguinte:
+The tool can be configured through the `.prettylog.yml` file, which can be located either locally (in the folder where the tool runs), when globally (in the `$HOME` folder). The file structure is as follows:
 
     timestamp:
       key:     <string>
@@ -75,23 +72,18 @@ pasta onde a ferramenta é executada), quando globalmente (na pasta `$HOME`). A 
       padding: <int>
       color:   <list of int>
 
-Cada chave configura a formatação de um campo do log, e o significado de cada propriedade é descrito abaixo:
+Each key configures the formatting of a field in the log, and the meaning of each property is described below:
 
-- **key**: Nome do campo a ser extraído do log da aplicação.
-- **visible**: Flag indicando se o campo será exibido pela ferramenta.
-- **padding**: Quantidade de espaços em branco a serem adicionados à direita do texto do campo.
-- **color/colors**: Atributos de cor usados para colorir o texto do campo. Até 3 valores podem ser informados 
-(foreground, background e effects), de acordo com a [tabela para cores ASCII](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
-- **format**: Atributo exclusivo para Timestamp que define o formato da data a ser exibido na tela. O valor desse atributo
-deve seguir as [especificações da linguagem Go](https://golang.org/pkg/time/#pkg-constants) para formato de datas.
+- **key**: Name of the field to be extracted from the application log.
+- **visible**: Flag indicating whether the field will be displayed by the tool.
+- **padding**: Number of blanks to be added to the right of the field text.
+- **color/colors**: Color attributes used to color the field text. Up to 3 values ​​can be informed (foreground, background and effects), according to the [table for ASCII colors](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
+- **format**: Unique attribute for Timestamp that defines the date format to be displayed on the screen. The value of this attribute you must follow the [Go language specifications](https://golang.org/pkg/time/#pkg-constants) for date format.
 
-## Utilização com outras ferramentas de linha de comando
+## Use with other command line tools
 
-Prettylog pode ser utilizado em conjunto com outras ferramentas de procesamento de output, como o `grep`. Entretanto, 
-para que a formatação da saída seja feita corretamente, é necessário desligar qualquer buffer que não seja por linha. 
-Por exemplo, com o `grep` basta utilizar a opção `--line-buffered`:
+Prettylog can be used in conjunction with other output processing tools, such as `grep`. However, for the output to be formatted correctly, it is necessary to turn off any buffer that is not per line. For example, with `grep` just use the `--line-buffered` option:
 
     app | grep --line-buffered -v debug | prettylog
 
-Se a ferramenta fizer uso de um buffer e não fornecer uma forma nativa de desligá-lo, tente usar o 
-[stdbuff](https://www.gnu.org/software/coreutils/manual/html_node/stdbuf-invocation.html).
+If the tool uses a buffer and does not provide a native way to turn it off, try using the [stdbuff](https://www.gnu.org/software/coreutils/manual/html_node/stdbuf-invocation.html).


### PR DESCRIPTION
## Activity Description

README.md was translated from Brazilian Portuguese to English in order to attract more contributors to the project.