### PR TITLE
Fix installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Command line tool that displays JSON logs in a human-friendly format.
 
 Go 1.17+:
 
-    go install github.com/globocom/prettylog
+    go install github.com/globocom/prettylog@latest
 
 Go 1.16 or older:
 


### PR DESCRIPTION
I tried to install following the README command, but I got this error

```
go: 'go install' requires a version when current directory is not in a module
    Try 'go install github.com/globocom/prettylog@latest' to install the latest version
```

![image](https://github.com/globocom/prettylog/assets/604917/97986682-6b61-40bc-9a03-5e1d195c1780)
